### PR TITLE
Set non-enumerable for Object.prototype.clone()

### DIFF
--- a/pacman.js
+++ b/pacman.js
@@ -1254,16 +1254,13 @@ Pacman.WALLS = [
 ];
 
 Object.prototype.clone = function () {
-    var i, newObj = (this instanceof Array) ? [] : {};
-    for (i in this) {
-        if (i === 'clone') {
-            continue;
-        }
-        if (this[i] && typeof this[i] === "object") {
-            newObj[i] = this[i].clone();
-        } else {
-            newObj[i] = this[i];
-        }
-    }
-    return newObj;
+  const newObj = this instanceof Array? [] : {};
+  var i, v;
+
+  for (i in this)  if (i !== 'clone')
+    v = this[i], newObj[i] = v && typeof v === 'object'? v.clone() : v;
+
+  return newObj;
 };
+
+Object.defineProperty(Object.prototype, 'clone', { enumerable: false });


### PR DESCRIPTION
"pacman.js" can't mix up w/ other scripts which rely on [`for...in`](https://developer.Mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) or [**Object.keys()**](https://developer.Mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) but don't check for [**hasOwnProperty()**](https://developer.Mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).

Any inclusions for built-in native objects should be accompanied by [**Object.defineProperty()**](https://developer.Mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) and have its new method set to `{ enumerable: false }`!

Here's the forum thread which has inspired this fix:  :D
https://forum.Processing.org/two/discussion/13501/p5-js-crash-when-including-a-new-js-file-packman-js-in-the-same-html-file
